### PR TITLE
Add search bar for torillic theme

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>{% if page.title %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
+  <link rel="icon" type="image/x-icon" href="{{ config.theme.favicon | url }}">
+  <link href="{{ 'css/torillic.css'|url }}" rel="stylesheet">
+  {%- for path in config.extra_css %}
+  <link href="{{ path | url }}" rel="stylesheet">
+  {%- endfor %}
+  <style>
+    .torillic-background {
+      {% if config.theme.background_image %}
+      background-image: url("{{ config.theme.background_image | url }}");
+      {% endif %}
+    }
+  </style>
+  <script>
+    function toggleSpoiler(element) {
+      // add/remove "hidden" class
+      if (element.classList.contains("hidden")) {
+        element.classList.remove("hidden");
+      } else {
+        element.classList.add("hidden");
+      }
+    }
+  </script>
+</head>
+
+<body class="torillic-background">
+  <header class="torillic-header">
+    <h1>{{ config.site_name }}</h1>
+    <nav>
+      {% for nav_item in nav %}
+      {% if nav_item.children and not nav_item.url %}
+      <a class="{% if nav_item.active %}current{% endif %}" href="{{ nav_item.children[0].url|url }}">{{nav_item.title }}</a>
+      {% else %}
+      <a class="{% if nav_item.active %}current{% endif %}" href="{{ nav_item.url|url }}">{{nav_item.title }}</a>
+      {% endif %}
+      {% endfor %}
+    </nav>
+    {% if 'search' in config.plugins %}
+    <div class="search-container">
+      <input type="search" id="mkdocs-search-query" placeholder="Search..." title="Type search term here">
+      <div id="mkdocs-search-results" data-no-results-text="No results found"></div>
+    </div>
+    {% endif %}
+  </header>
+  <main class="torillic-page">
+    {# add page content #}
+    {{ page.content }}
+
+    {# add global contents on the root page, unless told not to #}
+    {% if page.meta.contents == "global" or ( page.is_homepage and page.meta.contents not in ("local", "none") )  %}
+    {% include "partials/global_contents.html" %}
+
+    {# add local contents on section homepages, unless told not to #}
+    {% elif page.meta.contents == "local" or ( page.parent and page == page.parent.children[0] and page.meta.contents not in ("global", "none") ) %}
+    {% include "partials/local_contents.html" %}
+
+    {% endif %}
+    
+    {# add a back arrow if there's a parent to go back to #}
+    {% if page.parent %}
+    {% include "partials/backlink.html" %}
+    {% endif %}
+  </main>
+  
+  {%- for script in config.extra_javascript %}
+  {{ script | script_tag }}
+  {%- endfor %}
+</body>
+
+</html>

--- a/docs/overrides/search.css
+++ b/docs/overrides/search.css
@@ -1,0 +1,11 @@
+.search-container {
+  margin-top: 1rem;
+}
+#mkdocs-search-results {
+  background: white;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
+  border: 1px solid #ddd;
+  max-height: 300px;
+  overflow-y: auto;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: https://782392c8-a276-48e2-b12d-a740e1fcb34b-00-2a149ufs0xftd.worf.rep
 theme:
   # name: material
   name: torillic
+  custom_dir: docs/overrides
 
 nav:
 - ...
@@ -12,3 +13,6 @@ plugins:
 # awesome-pages works well Torillic's contents pages as it allows an automatic nav to be generated from file structure
 - awesome-pages
 - search
+
+extra_css:
+  - overrides/search.css


### PR DESCRIPTION
## Summary
- customize Torillic theme to include a search bar when the search plugin is enabled
- style search results box
- register overrides directory in `mkdocs.yml`

## Testing
- `mkdocs build -q`

------
https://chatgpt.com/codex/tasks/task_e_688995645454832c8e6d301daa540044